### PR TITLE
Support jshint, autocomplete and snippets configuration without external requests

### DIFF
--- a/ace-element.html
+++ b/ace-element.html
@@ -8,11 +8,10 @@ license that can be found in the LICENSE file.
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<script src="./src-min-noconflict/ace.js"></script>
+<script src="./src-min-noconflict/ext-language_tools.js"></script>
+<script src="./src-min-noconflict/snippets/snippets.js"></script>
 
-<link rel="import" href="../iron-ajax/iron-ajax.html">
-<script src="src-min-noconflict/ace.js"></script>
-<script src="src-min-noconflict/ext-language_tools.js"></script>
-<script src="src-min-noconflict/snippets/snippets.js"></script>
 <dom-module id="ace-element">
     <link rel="stylesheet" href="./ace-element.css">
     <style type="text/css" media="screen">
@@ -33,18 +32,14 @@ license that can be found in the LICENSE file.
             padding-right: 6px;
         }
         [horizontal-layout] {
-        @apply(--layout-horizontal);
+          @apply(--layout-horizontal);
         }
 
         [vertical-layout] {
-        @apply(--layout-vertical);
+          @apply(--layout-vertical);
         }
     </style>
     <template>
-        <iron-ajax auto url="{{snippetsSrc}}" handle-as="text" on-response="snippetsLoaded"></iron-ajax>
-        <iron-ajax auto url="{{autoCompleteSrc}}" handle-as="json" on-response="autoCompleteSrcLoaded"></iron-ajax>
-        <iron-ajax auto url="{{jsHintConfigSrc}}" handle-as="json" on-response="jsHintConfigSrcLoaded"></iron-ajax>
-
         <div style="height: 100%" vertical-layout>
             <div id="editor"></div>
             <div style="line-height: 24px; color: #CFD8DC; background: #2F3129;" horizontal-layout>
@@ -56,9 +51,7 @@ license that can be found in the LICENSE file.
                 </div>
             </div>
         </div>
-
     </template>
 
     <script src="./ace-element.js"></script>
-
 </dom-module>


### PR DESCRIPTION
These changes allow you to configure `ace-editor`'s snippets, jshint and autocomplete specifying the options directly instead of a `url` which implies to download configuration files every time the editor is initialized.